### PR TITLE
Set TomEE to not use transactions for its connection factory

### DIFF
--- a/src/main/webapp/WEB-INF/resources.xml
+++ b/src/main/webapp/WEB-INF/resources.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <Resource id="RI_JMS_Durrable_Connection_Factory" type="TopicConnectionFactory">
+        TransactionSupport none
+    </Resource>
+</resources>


### PR DESCRIPTION
The issue where you have redelivery looks to be caused by the connection factory that is injected into the ReadTopic servlet is set to use XA transactions (the default). Your code then uses a connection from that factory in a non-transactional way, and nothing is committing the transaction, so it is rolling back and attempting delivery again.

The config applied in this PR simply sets the ConnectionFactory's `TransactionSupport` to `none`.

Hope that helps.